### PR TITLE
Hdfs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ that this deployment of TensorBoard will only work correctly if you have
 configured a Shared Filesystem.
 
 Since you have a VPN pointed at your cluster, you can pull up
-[hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo](hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo)
+[http://tensorboard.mnist-hdfs.l4lb.thisdcos.directory:6006](http://tensorboard.mnist-hdfs.l4lb.thisdcos.directory:6006)
 to view the TensorBoard UI. TensorBoard may take a couple of minutes to
 load the summary files. Once it finishes loading, you should be able to
 use this UI to visualize your model's training progress in real-time.

--- a/README.md
+++ b/README.md
@@ -55,32 +55,76 @@ this example, we would set the job fields as follows:
 "job_name" : "train_model"
 ```
 
-The `shared_filesystem` field is the last important piece to consider in the
-examples. This framework works best when you use a GCS bucket as a shared filesystem for
-summaries and checkpoint files. The `shared_filesystem` field should point to your
-GCS bucket with the following format:
+The `shared_filesystem` field is another important piece to consider in
+the options file. This framework works best with a Shared Filesystem (such
+as HDFS or GCS) as a backing store for summaries and checkpoint files. It
+supports both HDFS and GCS, but we recommend HDFS. If your `shared_filesystem` field
+is non-empty, it will be passed to your TensorFlow code at runtime as `log_dir` in the
+main function. If your `shared_filesystem` field is empty, the wrapper will pass in a
+persistent volume (living in `$MESOS_SANDBOX/tf-volume`) as `log_dir` instead.
+Note that distributed TensorFlow will _not_ be able to recover from failures
+automatically if the Chief Worker and the Parameter Servers
+do not all have access to the latest checkpoint file.
+
+### Using HDFS and TensorBoard (Recommended)
+
+Prerequisites:
+
+1. An installation of HDFS. This step can be easily completed with
+   `dcos package install hdfs`. Make sure to wait for the installation
+   to complete before continuing. You can monitor its progress with
+   `dcos hdfs plan status deploy`.
+1. A VPN to access your cluster's network. You can use DC/OS Tunnel
+   to easily set up a VPN. Make sure to install OpenVPN (`brew install
+   openvpn`), and also make sure you have SSH access to your cluster.
+   Install DC/OS Tunnel with `dcos package install tunnel-cli`, then
+   start the VPN with `sudo dcos tunnel vpn`. You may also need to add
+   the following addresses to your DNS resolvers in your local network
+   settings: 198.51.100.1, 198.51.100.2, 198.51.100.3.
+
+To use HDFS as a Shared Filesystem, simply set the `shared_filesystem` field
+to point to your HDFS installation. If you are using the default configuration
+for the certified HDFS package on DC/OS, for example, set the field to:
+
+```
+hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/path/to/folder
+```
+
+To try an example with this field already set, run `dcos package install
+beta-tensorflow --options=examples/mnist-with-summaries.json`. This example
+trains a simple MNIST classifier, and it writes extra summaries to TensorBoard
+for visualization. This example also sets `use_tensorboard: true`, which instructs
+the framework to deploy an instance of TensorBoard along with your job. Note
+that this deployment of TensorBoard will only work correctly if you have
+configured a Shared Filesystem.
+
+Since you have a VPN pointed at your cluster, you can pull up
+[hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo](hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo)
+to view the TensorBoard UI. TensorBoard may take a couple of minutes to
+load the summary files. Once it finishes loading, you should be able to
+use this UI to visualize your model's training progress in real-time.
+
+### Using Google Cloud Storage (Optional)
+
+Prerequisites:
+
+1. A GCS bucket. This bucket must either be public, or you will
+   need a Service Account Key with the "Storage Admin" permission.
+
+Although we recommend using HDFS, you can also use GCS as a Shared Filesystem. To
+use GCS, set the `shared_filesystem` field to match to:
 
 ```
 gs://<bucket-name>/path/to/folder
 ```
 
-See "Using Google Cloud Storage" for details on authentication.
-
-This path will be passed to your main function as `log_dir` at runtime. If you choose not
-to specify a shared filesystem, the wrapper will pass in a persistent volume (living in
-`$MESOS_SANDBOX/tf-volume`) as `log_dir` instead. Note that distributed TensorFlow will _not_
-be able to recover from failures automatically if the Chief Worker and the Parameter Servers
-do not all have access to the latest checkpoint file.
-
-To create your own examples or test custom configurations, use the [bin/new-config.sh](../bin/new-config.sh)
-script. It accepts the name of your example as the only argument, and it will generate a config template
-in the un-tracked `examples/local/` directory.
-
-## Using Google Cloud Storage (Optional)
-
-Having a shared filesystem to store checkpoints and summaries is useful for distributed training jobs, and TensorFlow has a lot of built-in support for GCS. To use GCS with DC/OS TensorFlow, there are 2 options:
+IMPORTANT: unless your GCS bucket is public, you will need to authenticate the framework
+           with GCS. To do so, you have two options:
 
 1. Adding a DC/OS secret called `/gcs_key` with your service account key.
-2. Passing in your stringified service account key as an environment variable (WARNING: this option is significantly less secure, as your creditions will be written to an open file in `$MESOS_SANDBOX`).
+1. Passing in your stringified service account key as an environment variable (WARNING: this option is significantly less secure, as your creditions will be written to an open file in `$MESOS_SANDBOX`).
 
-The first steps to using GCS are to create a bucket, create a service acount with the "Storage Admin" permission for that bucket, and download the service account JSON key. To use method 1, set `use_gcs_key_secret: true` and leave `gcs_key` blank (if this field is non-empty, it will overwrite the value pulled from your DC/OS secret). To use method 2, set `use_gcs_key_secret: false` and paste your stringified service account key to `gcs_key`.
+To use method 1, set `use_gcs_key_secret: true` and leave `gcs_key` blank (if
+this field is non-empty, it will overwrite the value pulled from your DC/OS
+secret). To use method 2, set `use_gcs_key_secret: false` and paste your stringified
+service account key to `gcs_key`.

--- a/examples/mnist-with-summaries.json
+++ b/examples/mnist-with-summaries.json
@@ -1,8 +1,8 @@
 {
   "service": {
     "name": "mnist-with-summaries",
-    "job_url": "https://github.com/dcos-labs/dcos-tensorflow-tools/archive/hdfs-updates.zip",
-    "job_path": "dcos-tensorflow-tools-hdfs-updates/examples/source/mnist_with_summaries",
+    "job_url": "https://downloads.mesosphere.com/tensorflow-dcos/examples/v1/dcos-tensorflow-tools-master.zip",
+    "job_path": "dcos-tensorflow-tools-master/examples/source/mnist_with_summaries",
     "job_name": "mnist_with_summaries",
     "job_context": "{\"learning_rate\":0.001,\"max_steps\":100000,\"run_name\":\"demo\"}",
     "shared_filesystem": "hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo",

--- a/examples/mnist-with-summaries.json
+++ b/examples/mnist-with-summaries.json
@@ -1,0 +1,22 @@
+{
+  "service": {
+    "name": "mnist-with-summaries",
+    "job_url": "https://github.com/dcos-labs/dcos-tensorflow-tools/archive/hdfs-updates.zip",
+    "job_path": "dcos-tensorflow-tools-hdfs-updates/examples/source/mnist_with_summaries",
+    "job_name": "mnist_with_summaries",
+    "job_context": "{\"learning_rate\":0.001,\"max_steps\":100000,\"run_name\":\"demo\"}",
+    "shared_filesystem": "hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo",
+    "use_gcs_key_secret": false,
+    "use_tensorboard": true,
+    "user": "root"
+  },
+  "gpu_worker": {
+    "count": 0
+  },
+  "worker": {
+    "count": 3
+  },
+  "parameter_server": {
+    "count": 2
+  }
+}

--- a/examples/source/mnist_with_summaries/README.md
+++ b/examples/source/mnist_with_summaries/README.md
@@ -1,4 +1,4 @@
 # MNIST with Summaries
 
 This is still just the simple MNIST model, only with more visualizations in TensorBoard. The code
-is based on (mnist_with_summaries.py)[https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py].
+is based on [mnist_with_summaries.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).

--- a/examples/source/mnist_with_summaries/README.md
+++ b/examples/source/mnist_with_summaries/README.md
@@ -1,0 +1,4 @@
+# MNIST with Summaries
+
+This is still just the simple MNIST model, only with more visualizations in TensorBoard. The code
+is based on (mnist_with_summaries.py)[https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py].

--- a/examples/source/mnist_with_summaries/mnist_with_summaries.py
+++ b/examples/source/mnist_with_summaries/mnist_with_summaries.py
@@ -1,0 +1,202 @@
+"""A simple MNIST classifier which displays summaries in TensorBoard.
+
+This is an unimpressive MNIST model, but it is a good example of using
+tf.name_scope to make a graph legible in the TensorBoard graph explorer, and of
+naming summary tags so that they are grouped meaningfully in TensorBoard.
+
+It demonstrates the functionality of every TensorBoard dashboard.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import tensorflow as tf
+
+from tensorflow.examples.tutorials.mnist import input_data
+
+FLAGS = None
+
+
+def train(server):
+    # Import data
+    mnist = input_data.read_data_sets(FLAGS.data_dir,
+                                      one_hot=True,
+                                      fake_data=FLAGS.fake_data)
+
+    # Create a multilayer model.
+    with tf.device(tf.train.replica_device_setter(
+            worker_device="/job:worker/task:%d" %
+                          server.server_def.task_index,
+            cluster=server.server_def.cluster)):
+
+        # Input placeholders
+        with tf.name_scope('input'):
+            x = tf.placeholder(tf.float32, [None, 784], name='x-input')
+            y_ = tf.placeholder(tf.float32, [None, 10], name='y-input')
+
+        with tf.name_scope('input_reshape'):
+            image_shaped_input = tf.reshape(x, [-1, 28, 28, 1])
+            tf.summary.image('input', image_shaped_input, 10)
+
+        # We can't initialize these variables to 0 - the network will get stuck.
+        def weight_variable(shape):
+            """Create a weight variable with appropriate initialization."""
+            initial = tf.truncated_normal(shape, stddev=0.1)
+            return tf.Variable(initial)
+
+        def bias_variable(shape):
+            """Create a bias variable with appropriate initialization."""
+            initial = tf.constant(0.1, shape=shape)
+            return tf.Variable(initial)
+
+        def variable_summaries(var):
+            """Attach a lot of summaries to a Tensor (for TensorBoard visualization)."""
+            with tf.name_scope('summaries'):
+                mean = tf.reduce_mean(var)
+                tf.summary.scalar('mean', mean)
+                with tf.name_scope('stddev'):
+                    stddev = tf.sqrt(tf.reduce_mean(tf.square(var - mean)))
+                tf.summary.scalar('stddev', stddev)
+                tf.summary.scalar('max', tf.reduce_max(var))
+                tf.summary.scalar('min', tf.reduce_min(var))
+                tf.summary.histogram('histogram', var)
+
+        def nn_layer(input_tensor, input_dim, output_dim, layer_name, act=tf.nn.relu):
+            """Reusable code for making a simple neural net layer.
+
+            It does a matrix multiply, bias add, and then uses ReLU to nonlinearize.
+            It also sets up name scoping so that the resultant graph is easy to read,
+            and adds a number of summary ops.
+            """
+            # Adding a name scope ensures logical grouping of the layers in the graph.
+            with tf.name_scope(layer_name):
+                # This Variable will hold the state of the weights for the layer
+                with tf.name_scope('weights'):
+                    weights = weight_variable([input_dim, output_dim])
+                    variable_summaries(weights)
+                with tf.name_scope('biases'):
+                    biases = bias_variable([output_dim])
+                    variable_summaries(biases)
+                with tf.name_scope('Wx_plus_b'):
+                    preactivate = tf.matmul(input_tensor, weights) + biases
+                    tf.summary.histogram('pre_activations', preactivate)
+                activations = act(preactivate, name='activation')
+                tf.summary.histogram('activations', activations)
+                return activations
+
+        hidden1 = nn_layer(x, 784, 500, 'layer1')
+
+        with tf.name_scope('dropout'):
+            keep_prob = tf.placeholder(tf.float32)
+            tf.summary.scalar('dropout_keep_probability', keep_prob)
+            dropped = tf.nn.dropout(hidden1, keep_prob)
+
+        # Do not apply softmax activation yet, see below.
+        y = nn_layer(dropped, 500, 10, 'layer2', act=tf.identity)
+
+        with tf.name_scope('cross_entropy'):
+            # The raw formulation of cross-entropy,
+            #
+            # tf.reduce_mean(-tf.reduce_sum(y_ * tf.log(tf.softmax(y)),
+            #                               reduction_indices=[1]))
+            #
+            # can be numerically unstable.
+            #
+            # So here we use tf.nn.softmax_cross_entropy_with_logits on the
+            # raw outputs of the nn_layer above, and then average across
+            # the batch.
+            diff = tf.nn.softmax_cross_entropy_with_logits(labels=y_, logits=y)
+            with tf.name_scope('total'):
+                cross_entropy = tf.reduce_mean(diff)
+        tf.summary.scalar('cross_entropy', cross_entropy)
+
+        with tf.name_scope('train'):
+            train_step = tf.train.AdamOptimizer(FLAGS.learning_rate).minimize(
+                cross_entropy)
+
+        with tf.name_scope('accuracy'):
+            with tf.name_scope('correct_prediction'):
+                correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(y_, 1))
+            with tf.name_scope('accuracy'):
+                accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+        tf.summary.scalar('accuracy', accuracy)
+
+        # Merge all the summaries and write them out to
+        # /tmp/tensorflow/mnist/logs/mnist_with_summaries (by default)
+        merged = tf.summary.merge_all()
+
+    # Set up Session
+    hooks = [tf.train.StopAtStepHook(last_step=FLAGS.max_steps)]
+    is_chief = server.server_def.task_index == 0
+    train_writer = tf.summary.FileWriter(FLAGS.log_dir + '/train', tf.get_default_graph()) if is_chief else None
+    test_writer = tf.summary.FileWriter(FLAGS.log_dir + '/test') if is_chief else None
+    with tf.train.MonitoredTrainingSession(master=server.target,
+                                           is_chief=is_chief,
+                                           hooks=hooks) as sess:
+
+        # Train the model, and also write summaries.
+        # Every 10th step, measure test-set accuracy, and write test summaries
+        # All other steps, run train_step on training data, & add training summaries
+
+        def feed_dict(train):
+            """Make a TensorFlow feed_dict: maps data onto Tensor placeholders."""
+            if train or FLAGS.fake_data:
+                xs, ys = mnist.train.next_batch(100, fake_data=FLAGS.fake_data)
+                k = FLAGS.dropout
+            else:
+                xs, ys = mnist.test.images, mnist.test.labels
+                k = 1.0
+            return {x: xs, y_: ys, keep_prob: k}
+
+        i = 0
+        while not sess.should_stop():
+            if i % 10 == 0:  # Record summaries and test-set accuracy
+                summary, acc = sess.run([merged, accuracy], feed_dict=feed_dict(False))
+                if is_chief:
+                    test_writer.add_summary(summary, i)
+                print('Accuracy at local step %s: %s' % (i, acc))
+            else:  # Record train set summaries, and train
+                if i % 100 == 99:  # Record execution stats
+                    run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
+                    run_metadata = tf.RunMetadata()
+                    summary, _ = sess.run([merged, train_step],
+                                          feed_dict=feed_dict(True),
+                                          options=run_options,
+                                          run_metadata=run_metadata)
+                    if is_chief:
+                        train_writer.add_run_metadata(run_metadata, 'step%03d' % i)
+                        train_writer.add_summary(summary, i)
+                        print('Adding run metadata for', i)
+                else:  # Record a summary
+                    summary, _ = sess.run([merged, train_step], feed_dict=feed_dict(True))
+                    if is_chief:
+                        train_writer.add_summary(summary, i)
+            i += 1
+        train_writer.close()
+        test_writer.close()
+
+
+def main(server, log_dir, context):
+    """
+    server: a tf.train.Server object (which knows about every other member of the cluster)
+    log_dir: a string providing the recommended location for training logs, summaries, and checkpoints
+    context: an optional dictionary of parameters (batch_size, learning_rate, etc.) specified at run-time
+    """
+
+    # Set FLAGS
+    FLAGS.log_dir = log_dir
+    FLAGS.fake_data = context.get('fake_data') or False
+    FLAGS.max_steps = context.get('max_steps') or 1000
+    FLAGS.learning_rate = context.get('learning_rate') or 0.001
+    FLAGS.dropout = context.get('dropout') or 0.9
+    FLAGS.data_dir = context.get('data_dir') or '/tmp'
+
+    if tf.gfile.Exists(FLAGS.log_dir):
+        tf.gfile.DeleteRecursively(FLAGS.log_dir)
+    tf.gfile.MakeDirs(FLAGS.log_dir)
+    train(server)
+

--- a/examples/source/mnist_with_summaries/mnist_with_summaries.py
+++ b/examples/source/mnist_with_summaries/mnist_with_summaries.py
@@ -122,8 +122,9 @@ def train(server, log_dir, context):
         tf.summary.scalar('cross_entropy', cross_entropy)
 
         with tf.name_scope('train'):
+            global_step = tf.contrib.framework.get_or_create_global_step()
             train_step = tf.train.AdamOptimizer(learning_rate).minimize(
-                cross_entropy)
+                cross_entropy, global_step=global_step)
 
         with tf.name_scope('accuracy'):
             with tf.name_scope('correct_prediction'):

--- a/examples/source/mnist_with_summaries/mnist_with_summaries.py
+++ b/examples/source/mnist_with_summaries/mnist_with_summaries.py
@@ -194,9 +194,5 @@ def main(server, log_dir, context):
     log_dir: a string providing the recommended location for training logs, summaries, and checkpoints
     context: an optional dictionary of parameters (batch_size, learning_rate, etc.) specified at run-time
     """
-
-    if tf.gfile.Exists(log_dir):
-        tf.gfile.DeleteRecursively(log_dir)
-    tf.gfile.MakeDirs(log_dir)
     train(server, log_dir, context)
 

--- a/examples/source/mnist_with_summaries/mnist_with_summaries.py
+++ b/examples/source/mnist_with_summaries/mnist_with_summaries.py
@@ -186,8 +186,9 @@ def train(server, log_dir, context):
                     if is_chief:
                         train_writer.add_summary(summary, i)
             i += 1
-        train_writer.close()
-        test_writer.close()
+        if is_chief:
+            train_writer.close()
+            test_writer.close()
 
 
 def main(server, log_dir, context):

--- a/examples/source/mnist_with_summaries/mnist_with_summaries.py
+++ b/examples/source/mnist_with_summaries/mnist_with_summaries.py
@@ -21,7 +21,16 @@ from tensorflow.examples.tutorials.mnist import input_data
 FLAGS = None
 
 
-def train(server):
+def train(server, log_dir, context):
+
+    # Set FLAGS
+    FLAGS.log_dir = log_dir
+    FLAGS.fake_data = context.get('fake_data') or False
+    FLAGS.max_steps = context.get('max_steps') or 1000
+    FLAGS.learning_rate = context.get('learning_rate') or 0.001
+    FLAGS.dropout = context.get('dropout') or 0.9
+    FLAGS.data_dir = context.get('data_dir') or '/tmp'
+
     # Import data
     mnist = input_data.read_data_sets(FLAGS.data_dir,
                                       one_hot=True,
@@ -187,16 +196,8 @@ def main(server, log_dir, context):
     context: an optional dictionary of parameters (batch_size, learning_rate, etc.) specified at run-time
     """
 
-    # Set FLAGS
-    FLAGS.log_dir = log_dir
-    FLAGS.fake_data = context.get('fake_data') or False
-    FLAGS.max_steps = context.get('max_steps') or 1000
-    FLAGS.learning_rate = context.get('learning_rate') or 0.001
-    FLAGS.dropout = context.get('dropout') or 0.9
-    FLAGS.data_dir = context.get('data_dir') or '/tmp'
-
-    if tf.gfile.Exists(FLAGS.log_dir):
-        tf.gfile.DeleteRecursively(FLAGS.log_dir)
-    tf.gfile.MakeDirs(FLAGS.log_dir)
-    train(server)
+    if tf.gfile.Exists(log_dir):
+        tf.gfile.DeleteRecursively(log_dir)
+    tf.gfile.MakeDirs(log_dir)
+    train(server, log_dir, context)
 

--- a/examples/source/mnist_with_summaries/mnist_with_summaries.py
+++ b/examples/source/mnist_with_summaries/mnist_with_summaries.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 import argparse
 import os
 import sys
+import datetime
 
 import tensorflow as tf
 
@@ -28,6 +29,7 @@ def train(server, log_dir, context):
     learning_rate = context.get('learning_rate') or 0.001
     dropout = context.get('dropout') or 0.9
     data_dir = context.get('data_dir') or '/tmp'
+    run_name = context.get('run_name') or datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
 
     # Import data
     mnist = input_data.read_data_sets(data_dir,
@@ -140,8 +142,8 @@ def train(server, log_dir, context):
     # Set up Session
     hooks = [tf.train.StopAtStepHook(last_step=max_steps)]
     is_chief = server.server_def.task_index == 0
-    train_writer = tf.summary.FileWriter(log_dir + '/train', tf.get_default_graph()) if is_chief else None
-    test_writer = tf.summary.FileWriter(log_dir + '/test') if is_chief else None
+    train_writer = tf.summary.FileWriter(log_dir + '/train-' + run_name, tf.get_default_graph()) if is_chief else None
+    test_writer = tf.summary.FileWriter(log_dir + '/test-' + run_name) if is_chief else None
     with tf.train.MonitoredTrainingSession(master=server.target,
                                            is_chief=is_chief,
                                            hooks=hooks) as sess:


### PR DESCRIPTION
This PR updates the README to include documentation for HDFS and TensorBoard. It also adds a new example called `mnist_with_summaries.py`, which is basically just MNIST with more visualizations available in TensorBoard. Since users will now easily be able to deploy / access an instance of TensorBoard with their jobs, it seemed useful to have a simple example with good TensorBoard integration.

~~TODO~~(done): before this is merged, we need to upload the new examples zip to https://downloads.mesosphere.com/tensorflow-dcos/examples/v1/dcos-tensorflow-tools-master.zip and sanity check `examples/mnist-with-summaries.json`.