### PR TITLE
[RELEASE-817] Update MNIST with summaries for improved HDFS interop

### DIFF
--- a/examples/mnist-with-summaries-kerberized.json
+++ b/examples/mnist-with-summaries-kerberized.json
@@ -1,0 +1,32 @@
+{
+    "service": {
+        "name": "tensorflow",
+        "security": {
+            "kerberos": {
+                "enabled": true,
+                "kdc": {
+                    "hostname": "kdc.marathon.autoip.dcos.thisdcos.directory",
+                    "port": 2500
+                },
+                "primary": "tensorflow",
+                "realm": "LOCAL",
+                "keytab_secret": "__dcos_base64__tensorflow_keytab"
+            }
+        },
+        "hdfs": {
+            "config_uri": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+        },
+        "shared_filesystem": "hdfs://default/tensorflow",
+        "job_url": "https://downloads.mesosphere.com/tensorflow-dcos/examples/v1/dcos-tensorflow-tools-master.zip",
+        "job_path": "dcos-tensorflow-tools-master/examples/source/mnist_with_summaries",
+        "job_name": "mnist_with_summaries",
+        "job_context": "{\"learning_rate\":0.001,\"max_steps\":100000,\"run_name\":\"demo\"}",
+        "use_tensorboard": true
+    },
+    "parameter_server": {
+        "count": 1
+    },
+    "worker": {
+        "count": 2
+    }
+}

--- a/examples/mnist-with-summaries.json
+++ b/examples/mnist-with-summaries.json
@@ -1,14 +1,15 @@
 {
   "service": {
     "name": "mnist-with-summaries",
+    "hdfs": {
+      "config_uri": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+    },
     "job_url": "https://downloads.mesosphere.com/tensorflow-dcos/examples/v1/dcos-tensorflow-tools-master.zip",
     "job_path": "dcos-tensorflow-tools-master/examples/source/mnist_with_summaries",
     "job_name": "mnist_with_summaries",
     "job_context": "{\"learning_rate\":0.001,\"max_steps\":100000,\"run_name\":\"demo\"}",
-    "shared_filesystem": "hdfs://name-0-node.hdfs.autoip.dcos.thisdcos.directory:9001/mnistdemo",
-    "use_gcs_key_secret": false,
-    "use_tensorboard": true,
-    "user": "root"
+    "shared_filesystem": "hdfs://default/tensorflow",
+    "use_tensorboard": true
   },
   "gpu_worker": {
     "count": 0
@@ -17,6 +18,6 @@
     "count": 3
   },
   "parameter_server": {
-    "count": 2
+    "count": 1
   }
 }


### PR DESCRIPTION
This PR updates the mnist-with-summaries example to use an `hdfs://default/`-based `shared_filesystem` and also adds an example with Kerberos support.